### PR TITLE
Update signature in table even if parameter count doesn't match

### DIFF
--- a/prototypes/two/src/App.js
+++ b/prototypes/two/src/App.js
@@ -369,7 +369,7 @@ function Succinct(props) {
 
     // TODO make more sophisticated parser that can handle functions as parameters in signature
     function validSignature(text) {
-        let sides = text.split(/\s+->\s+/g);
+        let sides = text.split(/->/g);
 
         if (sides.length !== 2) {
             return false;

--- a/prototypes/two/src/App.js
+++ b/prototypes/two/src/App.js
@@ -368,7 +368,7 @@ function Succinct(props) {
     }
 
     // TODO make more sophisticated parser that can handle functions as parameters in signature
-    function validSignature(text, modTab) {
+    function validSignature(text) {
         let sides = text.split(/\s+->\s+/g);
 
         if (sides.length !== 2) {
@@ -380,7 +380,7 @@ function Succinct(props) {
 
         let noNull = paramTypes !== null && outType !== null;
 
-        return noNull && paramTypes.length === modTab.params.length && outType.length === 1;
+        return noNull && paramTypes.length >= 1 && outType.length === 1;
     }
 
     const reals = props.tables.map((table, index) => (
@@ -404,7 +404,7 @@ function Succinct(props) {
                 dummy={false}
                 placeholder='Signature'
                 text={props.disabled ? table.signature : undefined}
-                isValid={(text) => validSignature(text, table)}
+                isValid={(text) => validSignature(text)}
                 onValid={(text) => tableChange({...table,
                                                 signature: text},
                                                table)}


### PR DESCRIPTION
Here's the bug that this change fixes:
If you make a signature with n inputs, and *then* add parameters so that the total number of parameters becomes n, then both the "Show Combined Program" and the snapshot sent to the server will contain yellow instead of the complete signature. This is because the validSignature check (and subsequent tableChange call) only happens when the user edits the signature field. For now, let's remove the parameter-count check. In general, validSignature should not depend on the table, so I removed that argument to validSignature. More generally, whenever a validity check involves multiple UI components, the check should be performed in table calculation (not in the input validation of individual fields). Moreover, any check failure should be displayed separately from the two conflicting components, and certainly not with the earlier-in-design-recipe component. We already do that for when a formula is syntactically valid but produces an error on a test example: errors such as "3 ain't a string" are shown not by turning "3" red or turning "(string-length s)" red, but as a message elsewhere in the interface.